### PR TITLE
Update scope name

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         }],
         "grammars": [{
             "language": "ballerina",
-            "scopeName": "source.bal",
+            "scopeName": "source.ballerina",
             "path": "./syntaxes/ballerina.tmLanguage"
         }]
     }

--- a/syntaxes/ballerina.tmLanguage
+++ b/syntaxes/ballerina.tmLanguage
@@ -669,7 +669,7 @@
 
 	</dict>		
 	<key>scopeName</key>
-	<string>source.bal</string>
+	<string>source.ballerina</string>
 	<key>uuid</key>
 	<string>c01f5512-489a-41bd-ba5d-caf4b55ae3b3</string>
 </dict>


### PR DESCRIPTION
This PR updates the scope name. This grammar file is planned to use for the syntax highlighting Ballerina files in GitHub. The reviewers has suggested to change the scope name to avoid any conflicts in the future. Please refer [this](https://github.com/github/linguist/pull/3818).

