### PR TITLE
Drop output from language server

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -26,10 +26,32 @@ exports.activate = function(context) {
 
 	const forceDebug = (process.env.LSDEBUG === "true");
 
+	if (process.env.VERBOSE !== "true") {
+		// If we're not in debug mode, drop all the output sent from the language server
+		// At the moment the only output sent from the language server are errors printed to the standard error
+		// These errors only distracts the user of the plugin as they are only useful for language-server developers
+		// If you want to see the output run with,
+		// `VERBOSE=true code --extensionDevelopmentPath=/home/aruna/projects/ballerina/plugin-vscode`
+		clientOptions.outputChannel = dropOutputChannel;
+	}
+
 	let disposable = new LanguageClient('ballerina-vscode', 'Ballerina vscode lanugage client',
 		serverOptions, clientOptions, forceDebug).start();
 
 	// Push the disposable to the context's subscriptions so that the 
 	// client can be deactivated on extension deactivation
 	context.subscriptions.push(disposable);
+}
+
+// This channel ignores(drops) all requests it receives.
+// So the user won't see any output sent through this channel
+const dropOutputChannel = {
+	name: 'dropOutputChannel',
+	append: () => {},
+	appendLine: () => {},
+	clear: () => {},
+	show: () => {},
+	show: () => {},
+	hide: () => {},
+	dispose: () => {},
 }


### PR DESCRIPTION
At the moment the only output sent from the language server is whats print to the standard error of the lang-server process.
These errors are not useful to the user of the plugin.

We'll drop these for now.