### PR TITLE
Add option to set ballerina sdk path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,18 @@
                 "scopeName": "source.ballerina",
                 "path": "./syntaxes/ballerina.tmLanguage"
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "Ballerina configuration",
+            "properties": {
+                "ballerina.sdk": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "Specifies the path to the ballerina sdk"
+                }
+            }
+        }
     },
     "main": "./extension.js",
     "scripts": {

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,20 @@
                                     <artifactId>${langserver.launcher.id}</artifactId>
                                     <version>${langserver.launcher.version}</version>
                                     <type>jar</type>
+                                    <classifier>jar-with-dependencies</classifier>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${basedir}/server-build/</outputDirectory>
                                     <destFileName>langserver.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.ballerinalang</groupId>
+                                    <artifactId>${langserver.launcher.id}</artifactId>
+                                    <version>${langserver.launcher.version}</version>
+                                    <type>jar</type>
+                                    <classifier>jar-with-non-ballerina-dependencies</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/server-build/</outputDirectory>
+                                    <destFileName>langserver-no-bal-deps.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -70,6 +81,6 @@
     </build>
     <properties>
         <langserver.launcher.id>language-server-stdio-launcher</langserver.launcher.id>
-        <langserver.launcher.version>0.95.6</langserver.launcher.version>
+        <langserver.launcher.version>0.95.1-SNAPSHOT</langserver.launcher.version>
     </properties>
 </project>


### PR DESCRIPTION
Use the stdio launcher jar which does not contain dependencies from ballerina.org group when the path to ballerina sdk configuration is set.

When the sdk path is set these dependencies are resolved using the jars inside `<sdk-location>/bre/lib`

Related PR ballerinalang/language-server#76